### PR TITLE
Include converter as Java files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Commands:
   agentpath    prints the path of the extracted async-profiler agent
   jattachpath  prints the path of the extracted jattach binary
   supported    fails if this JAR does not include a profiler for the current OS and architecture
-  converter    run the included converter JAR
+  converter    run the included converter
   version      version of the included async-profiler
   clear        clear the directory used for storing extracted files
 ```
@@ -113,7 +113,7 @@ your current OS and architecture.
 
 ### converter
 
-`java -jar ap-loader.jar converter` is equivalent to calling the included `jconverter.jar`:
+`java -jar ap-loader.jar converter` is equivalent to calling the included converters:
 
 ```sh
 java -jar ap-loader.jar converter <Converter> [options] <input> <output>
@@ -123,7 +123,7 @@ java -jar ap-loader.jar converter jfr2flame <input.jfr> <output.html>
 ```
 
 The available converters depend on the included async-profiler version.
-Call `java -jar converter` to a list of available converters, see
+Call `java -jar ap-loader.jar converter` to a list of available converters, see
 [the source code on GitHub](https://github.com/jvm-profiling-tools/async-profiler/blob/master/src/converter/Main.java)
 for more details.
 
@@ -162,6 +162,8 @@ the [main API class](https://github.com/jvm-profiling-tools/async-profiler/blob/
 from the async-profiler.jar.
 
 The API of the `AsyncProfilerLoader` can be used to execute all commands of the CLI programmatically.
+
+The converters reside in the `one.converter` package.
 
 ### Snapshots
 
@@ -253,7 +255,7 @@ Commands:
 Changelog
 ---------
 
-- 10.11.2022: Improve Converter
+- 11.11.2022: Improve Converter
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ It requires a platform supported by async-profiler and Python 3.6+.
 ### Build the JARs using maven
 
 ```sh
-# download and unzip the platform releases that you want to include
-wget https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.8.3/async-profiler-2.8.3-macos.zip
-unzip -o async-profiler-2.8.3-macos.zip -d ap-releases
+# download the release sources and binaries
+python3 ./bin/releaser.py download 2.8.3
+
 # build the JAR for the release
 # maven might throw warnings, related to the project version setting,
 # but the alternative solutions don't work, so we ignore the warning for now
@@ -249,6 +249,11 @@ Commands:
     clear             clear the ap-releases and target folders for a fresh start
 
 ```
+
+Changelog
+---------
+
+- 10.11.2022: Improve Converter
 
 License
 -------

--- a/bin/copy_all_libs.sh
+++ b/bin/copy_all_libs.sh
@@ -4,9 +4,9 @@
 set -e
 
 OWN_DIR=$(dirname "$0")
-
+VERSION_PLATFORM=$2
 # extract the version without the platform suffix
-version=$(echo "$2" | cut -d '-' -f 1)
+version=$(echo "$VERSION_PLATFORM" | cut -d '-' -f 1)
 echo "version: $version"
 cd "$1" || exit 1
 rm -fr target/classes/libs
@@ -24,15 +24,13 @@ for f in ap-releases/async-profiler-$version-*; do
   cp "$f/build/jattach" "target/classes/libs/jattach-$version-$platform"
 done
 first_folder=$(echo ap-releases/async-profiler-$version-linux* | cut -d " " -f 1)
-# copy the converter and profile.sh
-echo "Copy $first_folder/build/converter.jar"
-cp "$first_folder/build/converter.jar" "target/classes/libs/converter-$version.jar"
+# copy the profile.sh
 echo "Copy $first_folder/profiler.sh"
 cp "$first_folder/profiler.sh" "target/classes/libs/profiler-$version.sh"
 python3 "$OWN_DIR/profile_processor.py" "target/classes/libs/profiler-$version.sh"
-# extract the async-profiler JAR
-echo "Extracting $first_folder/build/async-profiler.jar"
+
 python3 "$OWN_DIR/timestamp.py" > "target/classes/libs/ap-timestamp-$version"
 echo "$version" > target/classes/libs/ap-version
-unzip -o "$first_folder/build/async-profiler*" "*.class" -d "target/classes"
-cp ap-releases/async-profiler-$version-code/src/api/one/profiler/*.java src/main/java/one/profiler
+
+echo "Copy Java sources"
+python3 "$OWN_DIR/copy_java_sources.py" "$BASEDIR" "$VERSION_PLATFORM"

--- a/bin/copy_java_sources.py
+++ b/bin/copy_java_sources.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python3
+
+"""
+./copy_java_sources.py <base_dir> <artifact version, like 2.8.3-macos>
+"""
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+BASEDIR = Path(sys.argv[1])
+RELEASE = sys.argv[2]
+VERSION = RELEASE.split("-")[0]
+AP_SOURCE_DIR = BASEDIR / "ap-releases" / f"async-profiler-{VERSION}-code" / "src"
+AP_CONVERTER_SOURCE_DIR = AP_SOURCE_DIR / "converter"
+AP_API_SOURCE_DIR = AP_SOURCE_DIR / "api" / "one" / "profiler"
+TARGET_SOURCE_DIR = BASEDIR / "src" / "main" / "java"
+TARGET_ONE_DIR = TARGET_SOURCE_DIR / "one"
+TARGET_ONE_PROFILER_DIR = TARGET_ONE_DIR / "profiler"
+TARGET_CONVERTER_DIR = TARGET_ONE_DIR / "converter"
+
+assert AP_SOURCE_DIR.exists(), f"Source directory {AP_SOURCE_DIR} does not exist"
+assert AP_CONVERTER_SOURCE_DIR.exists(), f"Source directory {AP_CONVERTER_SOURCE_DIR} does not exist"
+assert AP_API_SOURCE_DIR.exists()
+assert TARGET_SOURCE_DIR.exists()
+assert TARGET_ONE_PROFILER_DIR.exists()
+
+PROJECT_FILES = ["AsyncProfilerLoader.java"]
+
+DRY_RUN = False
+
+os.chdir(BASEDIR)
+
+print("Remove old files")
+for f in TARGET_ONE_PROFILER_DIR.glob("*"):
+    if f.name not in PROJECT_FILES:
+        if DRY_RUN:
+            print("would remove " + str(f))
+        else:
+            if f.is_dir():
+                f.rmdir()
+            else:
+                f.unlink()
+for f in TARGET_ONE_DIR.glob("*"):
+    if not f.is_dir() or f.name == "profiler":
+        continue
+    if DRY_RUN:
+        print("would remove " + str(f))
+    else:
+        shutil.rmtree(f)
+for f in TARGET_SOURCE_DIR.glob("*.java"):
+    if DRY_RUN:
+        print("would remove " + str(f))
+    else:
+        f.unlink()
+
+print("Copy api files")
+assert next(AP_API_SOURCE_DIR.glob("*.java"), "empty") != "empty", f"{AP_API_SOURCE_DIR} is empty"
+for f in AP_API_SOURCE_DIR.glob("*.java"):
+    target_file = TARGET_ONE_PROFILER_DIR / f.name
+    if DRY_RUN:
+        print(f"would copy {f} to {target_file}")
+    else:
+        shutil.copy(f, target_file)
+
+
+print("Copy converter directories")
+for directory in AP_CONVERTER_SOURCE_DIR.glob("one/*"):
+    if not directory.is_dir():
+        continue
+    if DRY_RUN:
+        print(f"would copy {directory} to {TARGET_SOURCE_DIR / 'one' / directory.name}")
+    else:
+        shutil.copytree(directory, TARGET_SOURCE_DIR / 'one' / directory.name)
+
+print("Copy converters")
+# Problem: These converters reside in the default package
+os.makedirs(TARGET_CONVERTER_DIR, exist_ok=True)
+for f in AP_CONVERTER_SOURCE_DIR.glob("*.java"):
+    target_file = TARGET_CONVERTER_DIR / f.name
+    if DRY_RUN:
+        print(f"would modify and copy {f} to {target_file}")
+    else:
+        with open(f, "r") as source:
+            content = "package one.converter;\n" + source.read()
+        if f.name == "Main.java":
+            assert "java -cp converter.jar" in content
+            content = content.replace("java -cp converter.jar ", "java -cp ap-loader.jar one.converter.")
+        with open(target_file, "w") as target:
+            target.write(content)

--- a/bin/copy_java_sources.py
+++ b/bin/copy_java_sources.py
@@ -87,5 +87,7 @@ for f in AP_CONVERTER_SOURCE_DIR.glob("*.java"):
         if f.name == "Main.java":
             assert "java -cp converter.jar" in content
             content = content.replace("java -cp converter.jar ", "java -cp ap-loader.jar one.converter.")
+        elif "Usage: java " in content:
+            content = content.replace("Usage: java ", "Usage: java -cp ap-loader.jar ")
         with open(target_file, "w") as target:
             target.write(content)

--- a/bin/copy_libs.sh
+++ b/bin/copy_libs.sh
@@ -21,12 +21,10 @@ cp "$AP_RELEASE/build/jattach" \
 python3 "$OWN_DIR/timestamp.py" > "target/classes/libs/ap-timestamp-$version"
 echo "$version" > target/classes/libs/ap-version
 
-echo "Copy $AP_RELEASE/build/converter.jar"
-cp "$AP_RELEASE/build/converter.jar" "target/classes/libs/converter-$version.jar"
 echo "Copy $AP_RELEASE/profiler.sh"
 cp "$AP_RELEASE/profiler.sh" "target/classes/libs/profiler-$version.sh"
 python3 "$OWN_DIR/profile_processor.py" "target/classes/libs/profiler-$version.sh"
-echo "Extracting $AP_RELEASE/build/async-profiler.jar"
-unzip -o "ap-releases/async-profiler-$VERSION_PLATFORM/build/async-profiler.jar" \
-  "*.class" -d "target/classes"
-cp ap-releases/async-profiler-$version-code/src/api/one/profiler/*.java src/main/java/one/profiler
+
+echo "Copy Java sources"
+python3 "$OWN_DIR/copy_java_sources.py" "$BASEDIR" "$VERSION_PLATFORM"
+

--- a/src/main/java/one/profiler/AsyncProfilerLoader.java
+++ b/src/main/java/one/profiler/AsyncProfilerLoader.java
@@ -409,6 +409,8 @@ public final class AsyncProfilerLoader {
     List<String> profilerArgs = new ArrayList<>(Arrays.asList(args));
     if (profilerArgs.size() > 0 && profilerArgs.get(0).startsWith("jfr")) {
       profilerArgs.set(0, "one.converter." + profilerArgs.get(0));
+    } else {
+      profilerArgs.add("one.converter.Main");
     }
     argList.addAll(profilerArgs);
     return argList.toArray(new String[0]);

--- a/src/main/java/one/profiler/AsyncProfilerLoader.java
+++ b/src/main/java/one/profiler/AsyncProfilerLoader.java
@@ -47,7 +47,6 @@ public final class AsyncProfilerLoader {
   private static final String EXTRACTION_PROPERTY_NAME = "ap_loader_extraction_dir";
   private static String librarySuffix;
   private static Path extractedAsyncProfiler;
-  private static Path extractedConverter;
   private static Path extractedJattach;
   private static Path extractedProfiler;
   private static Path extractionDir;
@@ -110,7 +109,6 @@ public final class AsyncProfilerLoader {
       }
     }
     extractedAsyncProfiler = null;
-    extractedConverter = null;
     extractedJattach = null;
     extractedProfiler = null;
     extractionDir = null;
@@ -229,10 +227,6 @@ public final class AsyncProfilerLoader {
     return "libasyncProfiler-" + getLibrarySuffix();
   }
 
-  private static String getConverterFileName() {
-    return "converter-" + getVersion() + ".jar";
-  }
-
   private static String getJattachFileName() {
     return "jattach-" + getLibrarySuffix().replace(".so", "");
   }
@@ -295,22 +289,6 @@ public final class AsyncProfilerLoader {
     } catch (IOException e) {
       throw new IOException("Could not copy file " + fileName + " to " + destination, e);
     }
-  }
-
-  /**
-   * Extracts the converter JAR
-   *
-   * @return path to the extracted converter JAR
-   * @throws IllegalStateException if OS or arch are not supported
-   * @throws IOException if the extraction fails
-   */
-  public static Path getConverterPath() throws IOException {
-    if (extractedConverter == null) {
-      extractedConverter =
-          copyFromResources(
-              getConverterFileName(), getExtractionDirectory().resolve("converter.jar"));
-    }
-    return extractedConverter;
   }
 
   /**
@@ -426,9 +404,13 @@ public final class AsyncProfilerLoader {
   private static String[] processConverterArgs(String[] args) throws IOException {
     List<String> argList = new ArrayList<>();
     argList.add(System.getProperty("java.home") + "/bin/java");
-    argList.add("-jar");
-    argList.add(getConverterPath().toString());
-    argList.addAll(Arrays.asList(args));
+    argList.add("-cp");
+    argList.add(System.getProperty("java.class.path"));
+    List<String> profilerArgs = new ArrayList<>(Arrays.asList(args));
+    if (profilerArgs.size() > 0 && profilerArgs.get(0).startsWith("jfr")) {
+      profilerArgs.set(0, "one.converter." + profilerArgs.get(0));
+    }
+    argList.addAll(profilerArgs);
     return argList.toArray(new String[0]);
   }
 
@@ -647,7 +629,7 @@ public final class AsyncProfilerLoader {
     }
     out.println("  supported    fails if this JAR does not include a profiler");
     out.println("               for the current OS and architecture");
-    out.println("  converter    run the included converter JAR");
+    out.println("  converter    run the included converter");
     out.println("  version      version of the included async-profiler");
     out.println("  clear        clear the directory used for storing extracted files");
   }


### PR DESCRIPTION
Package the converter directly in the `one.converter` package and not in an included JAR as before.