### PR TITLE
add jbang-catalog. Fixes #6

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,10 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "ap-loader": {
+      "script-ref": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar",
+      "description": "async profiler loader. Use directly with `jbang ap-loader@jvm-profiling-tools/ap-loader` or use as agent with `jbang --javaagent=ap-loader@jvm-profile-tools/ap-loader ...`."
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
as discussed in #6 adds jbang catalog.

lets you run ap-loader with `jbang ap-loader@jvm-profiling-tools/ap-loader` 

If there was a https://github.com/jvm-profiling-tools/ap-loader repo it could be shortened to `jbang ap-loader@jvm-profiling-tools`