### PR TITLE
aliases for converters

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -3,7 +3,27 @@
   "aliases": {
     "ap-loader": {
       "script-ref": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar",
-      "description": "async profiler loader. Use directly with `jbang ap-loader@jvm-profiling-tools/ap-loader` or use as agent with `jbang --javaagent=ap-loader@jvm-profile-tools/ap-loader ...`."
+      "description": "async profiler loader. Use directly with `jbang ap-loader@jvm-profiling-tools/ap-loader` or use as agent with `jbang --javaagent\u003dap-loader@jvm-profile-tools/ap-loader ...`."
+    },
+    "jfr2nflx": {
+      "script-ref": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar",
+      "main": "one.converter.jfr2nflx",
+      "java-agents": []
+    },
+    "jfr2pprof": {
+      "script-ref": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar",
+      "main": "one.converter.jfr2pprof",
+      "java-agents": []
+    },
+    "jfr2flame": {
+      "script-ref": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar",
+      "main": "one.converter.jfr2flame",
+      "java-agents": []
+    },
+    "converter": {
+      "script-ref": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar",
+      "main": "one.converter.Main",
+      "java-agents": []
     }
   },
   "templates": {}


### PR DESCRIPTION
I know its available via `jbang ap-loader@jvm-profiling-tools converter` but I keep missing that thus thought it would be nice they are actually listed directly in the alias catalog.

Also allows for easy script install: `jbang app install jfr2flame@jvm-profiling-tools` 